### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dataqna",
     "name_pretty": "Data QnA",
     "product_documentation": "https://cloud.google.com/bigquery/docs/dataqna",
-    "client_documentation": "https://googleapis.dev/python/dataqna/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dataqna/latest",
     "issue_tracker": "",
     "release_level": "alpha",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.