### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dataqna",
     "name_pretty": "Data QnA",
     "product_documentation": "https://cloud.google.com/bigquery/docs/dataqna",
-    "client_documentation": "https://googleapis.dev/python/dataqna/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dataqna/latest",
     "issue_tracker": "",
     "release_level": "alpha",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ and answer service for BigQuery data.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-data-qna.svg
    :target: https://pypi.org/project/google-cloud-data-qna/
 .. _Data QnA: https://cloud.google.com/bigquery/docs/dataqna
-.. _Client Library Documentation: https://googleapis.dev/python/dataqna/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/dataqna/latest
 .. _Product Documentation: https://cloud.google.com/bigquery/docs/dataqna
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.